### PR TITLE
Passing in default window.WebSocket in browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensea/stream-js",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensea/stream-js",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "phoenix": "^1.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/stream-js",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "An SDK to receive pushed updates from OpenSea over websocket",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { Socket, Channel, LongPoll } from 'phoenix';
+import { Socket, Channel } from 'phoenix';
 import { collectionTopic } from './helpers';
 import {
   ClientConfig,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { Socket, Channel } from 'phoenix';
+import { Socket, Channel, LongPoll } from 'phoenix';
 import { collectionTopic } from './helpers';
 import {
   ClientConfig,
@@ -31,10 +31,14 @@ export class OpenSeaStreamClient {
     onError = (error) => this.error(error)
   }: ClientConfig) {
     const endpoint = apiUrl || ENDPOINTS[network];
+    const webTransportDefault =
+      typeof window !== 'undefined' ? window.WebSocket : undefined;
     this.socket = new Socket(endpoint, {
       params: { token },
+      transport: webTransportDefault,
       ...connectOptions
     });
+
     this.socket.onError(onError);
     this.channels = new Map<string, Channel>();
     this.logLevel = logLevel;
@@ -42,25 +46,25 @@ export class OpenSeaStreamClient {
 
   private debug(message: unknown) {
     if (this.logLevel <= LogLevel.DEBUG) {
-      console.debug(message);
+      console.debug(`[DEBUG]: ${message}`);
     }
   }
 
   private info(message: unknown) {
     if (this.logLevel <= LogLevel.INFO) {
-      console.info(message);
+      console.info(`[INFO]: ${message}`);
     }
   }
 
   private warn(message: unknown) {
     if (this.logLevel <= LogLevel.WARN) {
-      console.warn(message);
+      console.warn(`[WARN]: ${message}`);
     }
   }
 
   private error(message: unknown) {
     if (this.logLevel <= LogLevel.ERROR) {
-      console.error(message);
+      console.error(`[ERROR]: ${message}`);
     }
   }
 
@@ -90,6 +94,7 @@ export class OpenSeaStreamClient {
   private getChannel = (topic: string): Channel => {
     let channel = this.channels.get(topic);
     if (!channel) {
+      this.debug(`Creating channel for topic: "${topic}"`);
       channel = this.createChannel(topic);
     }
     return channel;
@@ -103,9 +108,12 @@ export class OpenSeaStreamClient {
     this.socket.connect();
 
     const topic = collectionTopic(collectionSlug);
+    this.debug(`Fetching channel ${topic}`);
     const channel = this.getChannel(topic);
+    this.debug(`Subscribing to ${eventType} events on ${topic}`);
     channel.on(eventType, callback);
     return () => {
+      this.debug(`Unsubscribing from ${eventType} events on ${topic}`);
       channel.leave().receive('ok', () => {
         this.channels.delete(topic);
         this.info(


### PR DESCRIPTION
## Change Overview
Trying to resolve an issue for `phoenix` that lead to web browsers not being compatible with the SDK.

## Impact of Change

<!-- Check all that apply and add other impacts that might not be listed -->

- [x] Bug fix
  - [ ] External Facing (resolves an issue customers are currently experiencing)
  - [ ] Security Impact (fixes a potential vulnerability)
- [ ] Feature
  - [ ] Visible Change (changes semver of API surface or other change that would impact user/dev experience)
  - [ ] High Usage (impacts a major part of the core workflow for users)
- [ ] Performance Improvement
- [ ] Refactoring
- [ ] Other: _Describe here_

## Detailed Technical Description of Change
Added some nice debug-level logging and attempted to resolve an issue in which the wrong `transport` is being used in the constructor for `Socket` [here](https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix/socket.js#L97)

## Testing Approach and Results

<!-- Outline how you will test the change, provide rationale for whether unit / dev / system tests are needed (or why not), and post the evidence of your testing -->

## Collateral Work or Changes

<!-- Provide analysis of the overall impacts caused by your change. Does another system need to be updated to support the change? Does a configuration file need to be updated? etc -->

## Operational Impact

<!-- Are new metrics available with this change? Are they being logged? Do new dashboards or operational alerts need to be setup? -->
