### PR TITLE
Monitor multiple collections

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -178,7 +178,20 @@ export class OpenSeaStreamClient {
     this.debug(`Listening for item bids on "${collectionSlug}"`);
     return this.on(EventType.ITEM_RECEIVED_BID, collectionSlug, callback);
   };
-
+  public multipleCollections = async (
+    event: EventType,
+    collections: string[],
+    callback: Callback<BaseStreamMessage<unknown>>
+  ) => {
+    const subscriptions = collections.map((collection) =>
+      this.on(event, collection, callback)
+    );
+    return () => {
+      for (const unsubscribe of subscriptions) {
+        unsubscribe();
+      }
+    };
+  };
   public onEvents = (
     collectionSlug: string,
     eventTypes: EventType[],


### PR DESCRIPTION
## Change Overview

Added the ability to monitor multiple collections for the same event so you don't have to have multiple separate listeners

## Impact of Change

It wont affect current users but just introduce a new way to interact with the client. 

- [ ] Bug fix
  - [ ] External Facing (resolves an issue customers are currently experiencing)
  - [ ] Security Impact (fixes a potential vulnerability)
- [x] Feature
  - [x] Visible Change (changes semver of API surface or other change that would impact user/dev experience)
  - [ ] High Usage (impacts a major part of the core workflow for users)
- [ ] Performance Improvement
- [ ] Refactoring
- [ ] Other: _Describe here_

## Detailed Technical Description of Change

Added function where you pass in event type you want to monitor and a list of collection slugs. It maps through the collection slugs and adds a listener for each one. Ends up grouping it into one big listener to make everything easier. 

## Before
```typescript
//trying to monitor nft-worlds and otherdeed
client.onItemReceivedOffer("nft-worlds",(body)=>{})
client.onItemReceivedOffer("otherdeed",(body)=>{})
```

## After
```typescript
client.multipleCollections(EventType.ITEM_RECEIVED_OFFER,["nft-worlds","otherdeed"],(body)=>{})
```

## Testing Approach and Results

WIP so will try to show tests in next commit

## Collateral Work or Changes

Nothing needs to be updated from my knowledge since this is just adding one more function to the client