### PR TITLE
Specify TypeScript typings file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prettier:fix": "prettier --write ."
   },
   "sideEffects": false,
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "phoenix": "^1.6.2"
   },


### PR DESCRIPTION
## Change Overview

Specify TypeScript typings file in package.json in order to resolve TS issues:

```
src/index.ts:1:37 - error TS7016: Could not find a declaration file for module '@opensea/stream-js'. '/Users/.../opensea-api-hello-world/node_modules/@opensea/stream-js/dist/index.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/opensea__stream-js` if it exists or add a new declaration (.d.ts) file containing `declare module '@opensea/stream-js';`

1 import { OpenSeaStreamClient } from "@opensea/stream-js";
```

```
src/index.ts:20:38 - error TS7006: Parameter 'event' implicitly has an 'any' type.

20 client.onItemListed("shroom-goons", (event) => {
```