### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import { OpenSeaStreamClient } from '@opensea/stream-js';
 import { WebSocket } from 'ws';
 
 const client = new OpenSeaStreamClient({
-  token: 'openseaApiKey'
+  token: 'openseaApiKey',
   connectOptions: {
     transport: WebSocket
   }


### PR DESCRIPTION
## Change Overview

This fixes a typo in the README, whereby the client connection request to the WebSocket API misses a comma in the connection parameters.

## Impact of Change

- [ ] Other: This only affects the documentation and does not have any impact of the library functionality. 

## Detailed Technical Description of Change

There are no technical changes, which is why this section is skipped.

## Testing Approach and Results

I tested the change locally, whereby I executed the code in the updated README with the CloneX collection, using the following snippet:
```
const client = new OpenSeaStreamClient({
  token: 'openseaApiKey',
  connectOptions: {
    transport: WebSocket
  }
```

## Collateral Work or Changes

Nothing else needs to be updated.

## Operational Impact

There are not impect on operations.
