### PR TITLE
upgrade version to 0.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensea/stream-js",
-  "version": "0.0.21-rc.1",
+  "version": "0.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensea/stream-js",
-      "version": "0.0.21-rc.1",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "phoenix": "^1.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/stream-js",
-  "version": "0.0.21-rc.1",
+  "version": "0.0.23",
   "description": "An SDK to receive pushed updates from OpenSea over websocket",
   "license": "MIT",
   "author": "OpenSea Developers",


### PR DESCRIPTION
## Change Overview
bump version to 0.0.23

```
➜  stream-js git:(cterech/v0.0.23) npm publish --dry-run
npm notice
npm notice 📦  @opensea/stream-js@0.0.23
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 5.7kB README.md
npm notice 2.5kB package.json
npm notice === Tarball Details ===
npm notice name:          @opensea/stream-js
npm notice version:       0.0.23
npm notice filename:      @opensea/stream-js-0.0.23.tgz
npm notice package size:  3.7 kB
npm notice unpacked size: 9.3 kB
npm notice shasum:        4a501e7450b020e11313b252f1993eca18eff716
npm notice integrity:     sha512-GBNdMvTmbKw1M[...]T11pW3bdlfTjQ==
npm notice total files:   3
npm notice
+ @opensea/stream-js@0.0.23
```
