### PR TITLE
Fixed http-cache-semantics vulnerable to Regular Expression Denial of Service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7031,9 +7031,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-proxy-agent": {
@@ -19667,9 +19667,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-proxy-agent": {


### PR DESCRIPTION
<!-- Check all that apply and add other impacts that might not be listed -->

- [x] Bug fix
  - [x] External Facing (resolves an issue customers are currently experiencing)
  - [x] Security Impact (fixes a potential vulnerability)
- [x] Feature
  - [x] Visible Change (changes semver of API surface or other change that would impact user/dev experience)
  - [x] High Usage (impacts a major part of the core workflow for users)
- [x] Performance Improvement
- [ ] Refactoring
- [ ] Other: _Describe here_

## Detailed Technical Description of Change
CVE-2022-25881
[CWE-1333](https://cwe.mitre.org/data/definitions/1333.html)

## Operational Impact
`http-cache` semantics contains an Inefficient Regular Expression Complexity , leading to Denial of Service. This affects of the project `ProjectOpenSea/stream-js` http-cache-semantics The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.

