### PR TITLE
fix: metadata update types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensea/stream-js",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "An SDK to receive pushed updates from OpenSea over websocket",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,25 +67,36 @@ export type BaseStreamMessage<Payload> = {
 
 export type Trait = {
   trait_type: string;
-  value: string;
-  display_type: string;
-  max_value: number;
-  trait_count: string;
-  order: number;
+  value: string | null;
+  display_type: string | null;
+  max_value: number | null;
+  trait_count: number | null;
+  order: number | null;
 };
 
-export interface BaseItemMetadataType extends Payload {
+interface BaseItemMetadataType extends Payload {
   name: string;
   image_url: string;
   animation_url: string;
   metadata_url: string;
 }
 
-export interface ItemMetadataUpdatePayload extends BaseItemMetadataType {
-  description: string;
-  background_color: string;
-  traits: [Trait];
+export interface ItemMetadataUpdatePayload {
+  collection: { slug: string };
+  item: {
+    chain: { name: string };
+    metadata: {
+      name: string | null;
+      image_url: string | null;
+      animation_url: string | null;
+      metadata_url: string | null;
+      description: string | null;
+      backrgound_color: string | null;
+      traits: Trait[];
+    };
+  };
 }
+
 export type ItemMetadataUpdate = BaseStreamMessage<ItemMetadataUpdatePayload>;
 
 export type Account = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,10 +43,17 @@ export enum EventType {
   TRAIT_OFFER = 'trait_offer'
 }
 
-export type BaseItemType = {
+interface BaseItemMetadataType {
+  name: string | null;
+  image_url: string | null;
+  animation_url: string | null;
+  metadata_url: string | null;
+}
+
+export type BaseItemType<Metadata = BaseItemMetadataType> = {
   nft_id: string;
   permalink: string;
-  metadata: BaseItemMetadataType;
+  metadata: Metadata;
   chain: {
     name: string;
   };
@@ -74,28 +81,16 @@ export type Trait = {
   order: number | null;
 };
 
-interface BaseItemMetadataType extends Payload {
-  name: string;
-  image_url: string;
-  animation_url: string;
-  metadata_url: string;
+interface ExtendedItemMetadataType extends BaseItemMetadataType {
+  description: string | null;
+  backrgound_color: string | null;
+  traits: Trait[];
 }
 
-export interface ItemMetadataUpdatePayload {
+export type ItemMetadataUpdatePayload = {
   collection: { slug: string };
-  item: {
-    chain: { name: string };
-    metadata: {
-      name: string | null;
-      image_url: string | null;
-      animation_url: string | null;
-      metadata_url: string | null;
-      description: string | null;
-      backrgound_color: string | null;
-      traits: Trait[];
-    };
-  };
-}
+  item: BaseItemType<ExtendedItemMetadataType>;
+};
 
 export type ItemMetadataUpdate = BaseStreamMessage<ItemMetadataUpdatePayload>;
 


### PR DESCRIPTION
## Change Overview

Fixes the types for item metadata update to actually reflect what's being sent.

Did verify how events look through the stream, as well as how they are serialised:
<img width="847" alt="Screenshot 2023-04-13 at 20 21 46" src="https://user-images.githubusercontent.com/8524109/231849414-b2a69629-47ca-4504-8193-fa0f99c72b78.png">



## Impact of Change

<!-- Check all that apply and add other impacts that might not be listed -->

- [x] Bug fix
  - [x] External Facing (resolves an issue customers are currently experiencing)
  - [ ] Security Impact (fixes a potential vulnerability)
- [ ] Feature
  - [ ] Visible Change (changes semver of API surface or other change that would impact user/dev experience)
  - [ ] High Usage (impacts a major part of the core workflow for users)
- [ ] Performance Improvement
- [ ] Refactoring
- [ ] Other: _Describe here_
