### PR TITLE
Fix exports types for esm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,24 +5,11 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: .nvmrc
-      - run: npm ci
-      - run: npm test
-      - run: npm run build
-
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -31,6 +18,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
+      - run: npm test
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,8 +7,11 @@ const config: Config.InitialOptions = {
   displayName: pack.name,
   id: pack.name,
   modulePaths: ['<rootDir>/src'],
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom'
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config.InitialOptions = {
   id: pack.name,
   modulePaths: ['<rootDir>/src'],
   preset: 'ts-jest/presets/default-esm',
+  extensionsToTreatAsEsm: ['.ts'],
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier:check": "prettier --check .",
     "prettier:check:package.json": "prettier-package-json --list-different",
     "prettier:fix": "prettier --write . && prettier-package-json --write package.json",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier:check": "prettier --check .",
     "prettier:check:package.json": "prettier-package-json --list-different",
     "prettier:fix": "prettier --write . && prettier-package-json --write package.json",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "jest"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "type": "module",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { Socket, Channel } from 'phoenix';
-import { collectionTopic } from './helpers';
+import { collectionTopic } from './helpers.js';
 import {
   ClientConfig,
   BaseStreamMessage,
@@ -18,8 +18,8 @@ import {
   Network,
   OnClientEvent,
   OrderValidationEvent
-} from './types';
-import { ENDPOINTS } from './constants';
+} from './types.js';
+import { ENDPOINTS } from './constants.js';
 
 export class OpenSeaStreamClient {
   private socket: Socket;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { Network } from './types';
+import { Network } from './types.js';
 
 export const ENDPOINTS = {
   [Network.MAINNET]: 'wss://stream.openseabeta.com/socket',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './client';
-export * from './types';
+export * from './client.js';
+export * from './types.js';

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -1,7 +1,15 @@
-import { EventType, LogLevel, OpenSeaStreamClient } from '../src';
-import WS from 'jest-websocket-mock';
-import { getSocket, getChannels, encode, mockEvent } from './helpers';
-import { collectionTopic } from '../src/helpers';
+import { jest } from '@jest/globals';
+import { WS } from 'jest-websocket-mock';
+import { getSocket, getChannels, encode, mockEvent } from './helpers.js';
+import {
+  BaseItemType,
+  EventType,
+  LogLevel,
+  OnClientEvent,
+  OpenSeaStreamClient,
+  Payload
+} from '../src/index.js';
+import { collectionTopic } from '../src/helpers.js';
 
 let server: WS;
 let streamClient: OpenSeaStreamClient;
@@ -131,7 +139,9 @@ describe('middleware', () => {
   test('single', () => {
     const collectionSlug = 'c1';
 
-    const onClientEvent = jest.fn().mockImplementation(() => true);
+    const onClientEvent = jest
+      .fn()
+      .mockImplementation(() => true) as OnClientEvent;
 
     streamClient = new OpenSeaStreamClient({
       ...clientOpts,
@@ -194,11 +204,10 @@ describe('middleware', () => {
   test('filter out events', () => {
     const collectionSlug = 'c1';
 
-    const onClientEvent = jest
-      .fn()
-      .mockImplementation(
-        (_c, _e, event) => event.payload.chain === 'ethereum'
-      );
+    const onClientEvent = jest.fn().mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (_c, _e, event: any) => event.payload.chain.name === 'ethereum'
+    ) as OnClientEvent;
 
     streamClient = new OpenSeaStreamClient({
       ...clientOpts,
@@ -214,10 +223,10 @@ describe('middleware', () => {
     const onEvent = jest.fn();
 
     const ethereumListing = mockEvent(EventType.ITEM_LISTED, {
-      chain: 'ethereum'
+      chain: { name: 'ethereum' }
     });
     const polygonListing = mockEvent(EventType.ITEM_LISTED, {
-      chain: 'polygon'
+      chain: { name: 'polygon' }
     });
 
     streamClient.onEvents(

--- a/tests/client.spec.ts
+++ b/tests/client.spec.ts
@@ -2,12 +2,10 @@ import { jest } from '@jest/globals';
 import { WS } from 'jest-websocket-mock';
 import { getSocket, getChannels, encode, mockEvent } from './helpers.js';
 import {
-  BaseItemType,
   EventType,
   LogLevel,
   OnClientEvent,
-  OpenSeaStreamClient,
-  Payload
+  OpenSeaStreamClient
 } from '../src/index.js';
 import { collectionTopic } from '../src/helpers.js';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,7 @@
     "outDir": "./dist",
     "strict": true,
     "declaration": true,
-    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
     "resolveJsonModule": true,
     "baseUrl": "."
   }


### PR DESCRIPTION
when using esm in my own repository and installing stream-js, i got this error:

```
error TS7016: Could not find a declaration file for module '@opensea/stream-js'. '/Users/rg/dev/seaport-gossip/node_modules/@opensea/stream-js/dist/index.modern.js' implicitly has an 'any' type.
  There are types at '/Users/rg/dev/seaport-gossip/node_modules/@opensea/stream-js/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@opensea/stream-js' library may need to update its package.json or typings.
```

adding this typings line to exports fixed for me.