### PR TITLE
fix(deps): update rollup bundled DOM Clobbering Gadget found scripts that leads to XSS 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9584,10 +9584,11 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },


### PR DESCRIPTION
## Change Overview
We discovered a DOM Clobbering vulnerability in rollup when bundling scripts that use import.meta.url or with plugins that emit and reference asset files from code in cjs/umd/iife format. The DOM Clobbering gadget can lead to cross-site scripting (XSS) in web pages where scriptless attacker-controlled HTML elements (an img tag with an unsanitized name attribute) are present.


<!-- Check all that apply and add other impacts that might not be listed -->

- [x] Bug fix
  - [ ] External Facing (resolves an issue customers are currently experiencing)
  - [x] Security Impact (fixes a potential vulnerability)
- [ ] Feature
  - [ ] Visible Change (changes semver of API surface or other change that would impact user/dev experience)
  - [ ] High Usage (impacts a major part of the core workflow for users)
- [x] Performance Improvement
- [ ] Refactoring
- [ ] Other: _Describe here_

[Weakness CWE-79](https://cwe.mitre.org/data/definitions/79.html)