### PR TITLE
fix: noop in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Types are included to make working with our event payload objects easier.
 All subscription methods return a callback function that will unsubscribe from a stream when invoked.
 
 ```typescript
-const unsubscribe = client.onItemMetadataUpdated('collection-slug', noop);
+const unsubscribe = client.onItemMetadataUpdated('collection-slug', () => {});
 
 unsubscribe();
 ```


### PR DESCRIPTION
## Change Overview

Fixes an issue in the README where the noop callback is used without being defined or imported in the unsubscribe example.
The previous example would not compile when copied directly.
It has been replaced with an inline empty function to keep the example simple, valid, and copy-paste friendly.